### PR TITLE
Replace VOLUME with ADD so image is self-contained

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ RUN mkdir /app
 ADD waco-kid/app-scm-1.rockspec /tmp/
 RUN cd /tmp && luarocks make app-scm-1.rockspec
 
-VOLUME ["/app"]
+ADD . /app
 
 ENTRYPOINT /usr/local/openresty/nginx/sbin/nginx -p /tmp -c /app/nginx/nginx.conf

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Only two variables really matter, `WK_ETCD_URL`, which should be the full url
 eg `http://10.0.0.1:2379` and `WK_ETCD_PREFIX` which defautls to `/vulcand`.
 
 ## Running
-Currently, Waco kid must be run from a checked out copy of the code. Run
-`docker run -it -e WK_ETCD_URL=http://${ETCD_SERVER_IP}:2379 -p 80:80 -v $PWD:/app
-waco-kid` from the root of the repo.
+Run `docker run -it -e WK_ETCD_URL=http://${ETCD_SERVER_IP}:2379 -p 80:80
+waco-kid` after building the image.
+
+## Development
+First build an image, then. Run
+`docker run -it -e WK_ETCD_URL=http://${ETCD_SERVER_IP}:2379 -p 80:80 -v
+$PWD:/app waco-kid` from the root of the repo. This mounts the current version
+of the app into the image so you don't need to rebuild every time.
+
+You can also run `./dev.sh` which will output the url to the container, but
+_does_ rebuild the image every time.

--- a/dev.sh
+++ b/dev.sh
@@ -6,5 +6,9 @@ docker build -t $TAG . &&\
 DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd) &&\
 CID=$(docker run -d -v "$DIR:/app" $TAG) &&\
 echo $CID > ./app.pid &&\
-IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${CID}) &&\
+if [ "x${DOCKER_HOST}" = 'x' ]; then
+  IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${CID})
+else
+  IP=$(docker-machine ip $(docker-machine active))
+fi
 echo "http://$IP:$PORT"


### PR DESCRIPTION
Instead of mounting the app in a volume in /app, just copy the files to
/app on build. For development the volume can always be made on the
command-line to retain the old functionality. I also renamed the the 
`run.sh` script `dev.sh` and made it work on the mac.
